### PR TITLE
Clarify RC file instructions and replace techfika

### DIFF
--- a/00_Start_here/README.md
+++ b/00_Start_here/README.md
@@ -12,20 +12,24 @@ In this section, we will be generating a keypair with Terraform that will be use
 
 ## Confirm authentication
 
-Source your *OpenStack RC File v3*
+Log on to the OpenStack control panel, go to the API Access section and
+download an *OpenStack RC File (Identity API v3)*.
+
+Source the downloaded file, in this example named `myproject-openrc.sh` and
+downloaded while logged in as `myuser`:
 
 ```shell
-$ source ~/Downloads/techfika-openrc.sh
-Please enter your OpenStack Password for project techfika as user techfika:
+$ source ~/Downloads/myproject-openrc.sh
+Please enter your OpenStack Password for project myproject as user myuser:
 ```
 
 ```shell
 $ openstack project list
-+----------------------------------+----------+
-| ID                               | Name     |
-+----------------------------------+----------+
-| abc51ede2adabc321e66b76ced1c2321 | techfika |
-+----------------------------------+----------+
++----------------------------------+-----------+
+| ID                               | Name      |
++----------------------------------+-----------+
+| abc51ede2adabc321e66b76ced1c2321 | myproject |
++----------------------------------+-----------+
 ```
 
 ## Run Terraform

--- a/01_Router_Networking_Bastion/variables.tf
+++ b/01_Router_Networking_Bastion/variables.tf
@@ -5,7 +5,7 @@ variable "keypair" {
 
   A map with a key (name of resource) and value (path to public key) (optinal)
 
-  Example: { "bastion" = "~/.ssh/techfika.pub" }
+  Example: { "bastion" = "~/.ssh/myproject.pub" }
 DESCRIPTION
 }
 variable "keypair_name" {


### PR DESCRIPTION
This makes it easier to know what to do in the initial authentication steps for someone not accustomed to OpenStack.
It also replaces a confusing/unexplained/unclear reference to "techfika" with more conventional names.