### PR TITLE
Fix missing variable lookup in metadata fields

### DIFF
--- a/01_Router_Networking_Bastion/main.tf
+++ b/01_Router_Networking_Bastion/main.tf
@@ -71,7 +71,7 @@ resource "openstack_compute_instance_v2" "bastion" {
   image_id          = lookup(var.images, lookup(each.value, "image", var.image))
 
   metadata = {
-    "Image used" = var.image
+    "Image used" = lookup(each.value, "image", var.image)
     group        = "bastion"
   }
 

--- a/02_Web_Servers_LBaaS/main.tf
+++ b/02_Web_Servers_LBaaS/main.tf
@@ -38,7 +38,7 @@ resource "openstack_compute_instance_v2" "web" {
   }
 
   metadata = {
-    "Image used" = var.image
+    "Image used" = lookup(each.value, "image", var.image)
     group        = "web"
   }
 


### PR DESCRIPTION
In the configurations for bastion and web servers the "Image used" metadata field incorrectly referenced `var.image` instead of looking up the image value in the corresponding `var.bastion_hosts` and `var.web_hosts` (still defaulting to `var.image` of course).

This meant that even if one had set a specific image name in `var.bastion_hosts` or `var.web_hosts`, the `var.image` one would be used instead, resulting in inaccurate metadata for the affected hosts.