### PR TITLE
Added Terraform version to Prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The repository is structured in 4 separated parts. Each can be followed as instr
 ### Prerequisites
 
 * OpenRC file from openstack sourced
-* Terraform
+* Terraform (version <1.3, the use of Swift as backend has been deprecated in later versions)
 * Empty tenant in openstack
 
 In order to use this repository on an existing openstack tenant, you will have to make adjustments in `example.auto.tfvars` to fit your environment of each section.


### PR DESCRIPTION
Since Swift has been deprecated as backend since Terraform v1.3 I added this information in the Prerequisites section until we can update the repo with a replacement.