### PR TITLE
Fix error on key creation

### DIFF
--- a/00_Start_here/output.tf
+++ b/00_Start_here/output.tf
@@ -6,4 +6,5 @@ output "keypair_public_key" {
 }
 output "keypair_private_key" {
   value = openstack_compute_keypair_v2.keypair.private_key
+  sensitive = true
 }


### PR DESCRIPTION
**Versions:**
Tested with terraform version v1.1.5 and v1.5.6. 

**Error:**
 ```shell
Error: Output refers to sensitive values
│ 
│   on output.tf line 7:
│    7: output "keypair_private_key" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was intended to be only internal, Terraform requires that any root module output
│ containing sensitive data be explicitly marked as sensitive, to confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as sensitive by adding the following argument:
│     sensitive = true
```
**Fix:**
Added the `sensitive = true` flag in the output file for the private key. 