### PR TITLE
Locking terraform version to latest 1.5branch 1.5.7

### DIFF
--- a/00_Start_here/output.tf
+++ b/00_Start_here/output.tf
@@ -6,4 +6,5 @@ output "keypair_public_key" {
 }
 output "keypair_private_key" {
   value = openstack_compute_keypair_v2.keypair.private_key
+  sensitive = true
 }

--- a/00_Start_here/versions.tf
+++ b/00_Start_here/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 3.1"
     }
   }
-  required_version = ">= 1.0"
+  required_version = "<= 1.5.8"
 }

--- a/01_Router_Networking/versions.tf
+++ b/01_Router_Networking/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 3.1"
     }
   }
-  required_version = ">= 1.0"
+  required_version = "<= 1.5.8"
 }

--- a/02_Bastion/versions.tf
+++ b/02_Bastion/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 3.1"
     }
   }
-  required_version = ">= 1.0"
+  required_version = "<= 1.5.8"
 }

--- a/03_Web_Servers_LBaaS/versions.tf
+++ b/03_Web_Servers_LBaaS/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 3.1"
     }
   }
-  required_version = ">= 1.0"
+  required_version = "<= 1.5.8"
 }


### PR DESCRIPTION
Reviving the guide.
More recent versions as in terraform 1.6 breaks the current layout of the repo. 
This pr locks terraform version.

